### PR TITLE
Added instructions to Target API Level 30

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ Also add the required permissions to your manifest:
 
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="com.farsitel.bazaar.permission.PAY_THROUGH_BAZAAR" />
+	
+### Targeting API Level 30 or higher
+If you are targeting Android API Level 30 (Android 11) or higher, you need to add the following to the manifest:
+
+	<queries>
+	    <package android:name="com.farsitel.bazaar" />
+
+	    <intent>
+	      <action android:name="ir.cafebazaar.pardakht.InAppBillingService.BIND" />
+	    </intent>
+	</queries>
 
 # Methods	
 Methods are inside `BazaarIAB` class.


### PR DESCRIPTION
Due to changes of "Package visibility in Android 11", some new content has to be Added to "AndroidManifest.xml" in order to work correctly on Android 11 or higher.

The instructions are added in this request to the Readme.